### PR TITLE
Codebase bug resolution

### DIFF
--- a/hooks/useLocalStorage.ts
+++ b/hooks/useLocalStorage.ts
@@ -1,14 +1,36 @@
+'use client';
+
 import { useEffect, useState } from 'react';
 
 export function useLocalStorage<T>(key: string, fallbackValue: T) {
-   const [value, setValue] = useState(fallbackValue);
+   const [value, setValue] = useState<T>(fallbackValue);
+   const [hydrated, setHydrated] = useState(false);
+
    useEffect(() => {
-      const stored = localStorage.getItem(key);
-      setValue(stored ? JSON.parse(stored) : fallbackValue);
+      if (typeof window === 'undefined') return;
+      try {
+         const stored = window.localStorage.getItem(key);
+         if (stored == null) {
+            setValue(fallbackValue);
+         } else {
+            setValue(JSON.parse(stored) as T);
+         }
+      } catch {
+         setValue(fallbackValue);
+      } finally {
+         setHydrated(true);
+      }
    }, [fallbackValue, key]);
 
    useEffect(() => {
-      localStorage.setItem(key, JSON.stringify(value));
+      // Prevent overwriting a previously-stored value on initial mount.
+      if (!hydrated) return;
+      if (typeof window === 'undefined') return;
+      try {
+         window.localStorage.setItem(key, JSON.stringify(value));
+      } catch {
+         // ignore storage write errors (quota/private mode/etc.)
+      }
    }, [key, value]);
 
    return [value, setValue] as const;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -12,18 +12,20 @@ export const saveToLocalStorage = <T>({
    key: string;
    state: T;
 }) => {
+   if (typeof window === 'undefined') return;
    try {
       // if (localStorage.getItem(key)) return
       const serializedState = JSON.stringify(state);
-      localStorage.setItem(key, serializedState);
+      window.localStorage.setItem(key, serializedState);
    } catch (e) {
       console.log(e);
    }
 };
 
 export const loadFromLocalStorage = ({ key }: { key: string }) => {
+   if (typeof window === 'undefined') return undefined;
    try {
-      const serializedState = localStorage.getItem(key);
+      const serializedState = window.localStorage.getItem(key);
       if (serializedState === null) return false;
       return JSON.parse(serializedState);
    } catch (e) {
@@ -58,14 +60,12 @@ export const calculateAccuracy = (errorCount: number, typedEntries: number) => {
 };
 
 export const formatTime = (time: number) => {
-   if (time === 60) {
-      return '00:60:00';
-   }
+   const totalSeconds = Math.max(0, Math.floor(time));
+   const hours = Math.floor(totalSeconds / 3600);
+   const minutes = Math.floor((totalSeconds % 3600) / 60);
+   const seconds = totalSeconds % 60;
 
-   const minutes = Math.floor(time / 60);
-   const seconds = Math.floor(time % 60);
-   const milliseconds = Math.floor((time % 60) / 1000);
-   return `${minutes.toString().padStart(2, '0')}:${seconds
+   return `${hours.toString().padStart(2, '0')}:${minutes
       .toString()
-      .padStart(2, '0')}:${milliseconds.toString().padStart(2, '0')}`;
+      .padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
 };


### PR DESCRIPTION
#### THIS IS A PULL REQUEST TEMPLATE!

⚠️ This helps you complete a pull request. Please follow the instructions below. Reminder that you are bound to abide by the [Code of Conduct](/CODE_OF_CONDUCT.md) ⚠️

### Submission Checklist

---

Please complete the below checklist. Failure to follow these instructions may result in your pull request being closed without review.

### What issue does this PR closes?
<!-- Add tag of the issue or describe the problem your PR solves. -->
close #
This PR addresses three bugs:
1.  **SSR Safety & Robustness for `localStorage`**: Direct `localStorage` access caused SSR errors, and `useLocalStorage` lacked error handling for parsing stored data and would clobber existing values on initial mount.
2.  **Incorrect Time Formatting**: The `formatTime` utility produced incorrect `hh:mm:ss` values (e.g., `00:60:00`) and included a non-functional milliseconds component.

### Description of file changes
<!-- A detailed description of the changes made in this pull request. -->
*   **`hooks/useLocalStorage.ts`**:
    *   Added `typeof window === 'undefined'` checks to prevent SSR errors.
    *   Implemented `try/catch` blocks for `JSON.parse` to handle malformed stored data gracefully.
    *   Introduced a `hydrated` state to prevent overwriting existing `localStorage` values on the initial component mount.
*   **`lib/utils.ts`**:
    *   **`saveToLocalStorage` & `loadFromLocalStorage`**: Added `typeof window === 'undefined'` checks for SSR safety.
    *   **`formatTime`**: Rewrote the function to correctly calculate and format time into `hh:mm:ss` from total seconds, removing the incorrect milliseconds calculation and special casing for `60` seconds.

### Is this PR still in progress or completed?
- [ ] This PR is still a work in progress (WIP)
- [x] This PR is completed and ready for review
- [ ] Did you edit the package.json or pnpm.yaml? If yes, explain reason for modification and add the `dependencies` label to this PR. <br>

### Screenshot if applicable
<!-- screenshot of the feature implemented by this issue -->

### Additional Information
<!-- Any additional information or context about this PR. -->

---
<a href="https://cursor.com/background-agent?bcId=bc-1206e792-db66-4414-a5fb-4bda47ff3534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1206e792-db66-4414-a5fb-4bda47ff3534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

